### PR TITLE
Remove list of core contributors

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,8 +65,6 @@ for using and studying graphs.
 
 The maintainers of the JuliaGraphs packages can be found at [Github People](https://github.com/orgs/JuliaGraphs/people). Each package has its own GitHub page listing the contributions of individuals. The maintainers of these packages appreciate every contribution.
 
-The current core maintainers are [Seth Bromberger](https://github.com/sbromberger), [James Fairbanks](https://github.com/jpfairbanks), and [Julio Hoffimann](https://github.com/juliohm).
-
 # Related Packages
 
 Here are some packages that are related to the packages maintained by JuliaGraphs.


### PR DESCRIPTION
@jpfairbanks @simonschoelly I'm suggesting deleting list of core contributors, but if you think an updated list makes sense, we can do that too.